### PR TITLE
:recycle: Refactor user loop and template vars

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,11 +29,14 @@
   template:
     mode: 0644
     src: zshrc.j2
-    owner: "{{ item.key }}"
-    dest: "~{{ item.key }}/.zshrc"
+    owner: "{{ user_shell.key }}"
+    dest: "~{{ user_shell.key }}/.zshrc"
   loop: "{{ __users__ | default({}) | dict2items }}"
-  # loop_control:
-  #   loop_var: user_shell
+  loop_control:
+    loop_var: user_shell
+  vars:
+    zsh_username: "{{ user_shell.key }}"
+    user_options: "{{ user_shell.value }}"
 
 - name: Check for .zfunctions directory.
   file:

--- a/templates/zshrc.j2
+++ b/templates/zshrc.j2
@@ -1,21 +1,17 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 fpath=("$HOME/.zfunctions" $fpath)
 
-{%- for username, options in __users__.iteritems() %}
-  {%- if username == item.key %}
-    {# Install prompt #}
-    {%- if options.has_key('zsh_prompt_install') and options.zsh_prompt_install %}
+{# Install prompt #}
+{%- if 'zsh_prompt_install' in user_options and user_options.zsh_prompt_install %}
 
 autoload -U promptinit && promptinit
-prompt {{ options.zsh_prompt_name | default(zsh_default_prompt_name) }}
+prompt {{ user_options.zsh_prompt_name | default(zsh_default_prompt_name) }}
 
-    {%- endif %}
-    {# Add custom lines #}
-    {%- if options.has_key('zsh_zshrc_content') and options.zsh_zshrc_content %}
+{%- endif %}
+{# Add custom lines #}
+{%- if 'zsh_zshrc_content' in user_options and user_options.zsh_zshrc_content %}
 
-{{ options.zsh_zshrc_content }}
+{{ user_options.zsh_zshrc_content }}
 
-    {%- endif %}
-  {% endif %}
-{% endfor %}
+{%- endif %}


### PR DESCRIPTION
Refactor tasks/main.yml to use `user_shell` for loop var and ownership. Simplify zshrc.j2 template by removing redundant for-loop and keys check. Introduce `user_options` for streamlined variable access.