### PR TITLE
🔧 chore: Update pure prompt URLs to version 1.23.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 zsh_default_prompt_name: pure
-zsh_default_prompt_download_url: https://raw.githubusercontent.com/sindresorhus/pure/v1.9.0/pure.zsh
-zsh_default_prompt_download_md5: "md5:2840d03e0b29098bec412e60eb4488ee"
-zsh_default_prompt_additional_url: https://raw.githubusercontent.com/sindresorhus/pure/v1.9.0/async.zsh
-zsh_default_prompt_additional_md5: "md5:5ed132fa66938aef4e5bb781950bb443"
+zsh_default_prompt_download_url: https://raw.githubusercontent.com/sindresorhus/pure/v1.23.0/pure.zsh
+zsh_default_prompt_download_md5: "md5:fd67d5413d26651cc65a63b8202beda4"
+zsh_default_prompt_additional_url: https://raw.githubusercontent.com/sindresorhus/pure/v1.23.0/async.zsh
+zsh_default_prompt_additional_md5: "md5:f637e174c69c9c2ec2faa1cf3b60c6f8"


### PR DESCRIPTION
This pull request updates the URLs for the Pure prompt to version 1.23.0. The update ensures you are using the latest version, which may include essential performance enhancements, bug fixes, and new features. Review the updated URLs to confirm they meet your requirements and are correctly applied.